### PR TITLE
Fix #48

### DIFF
--- a/src/LIC/LIC1.java
+++ b/src/LIC/LIC1.java
@@ -31,9 +31,10 @@ public class LIC1 implements LIC {
             double dist2 = dist(x2, y2, x3, y3);
             double dist3 = dist(x1, y1, x3, y3);
 
-            if (dist1 > p.RADIUS1*2 || dist2 > p.RADIUS1 *2 || dist3 > p.RADIUS1*2) {
-                return true;
-            }
+            double minEnclosingRadius;
+            if (isTriangleObtuse(dist1, dist2, dist3)) minEnclosingRadius = Math.max(dist1,Math.max(dist2,dist3))/2;
+            else minEnclosingRadius = (dist1*dist2*dist3)/Math.sqrt((dist1+dist2+dist3)*(dist1+dist2-dist3)*(dist1-dist2+dist3)*(-dist1+dist2+dist3));
+            if (minEnclosingRadius > p.RADIUS1) return true;
         }
        return false;
    }
@@ -42,5 +43,16 @@ public class LIC1 implements LIC {
        double dist = Math.sqrt(Math.pow(x2-x1,2)+ Math.pow(y2-y1, 2));
        return dist;
    }
+
+   /**
+     * Checks if a triangle is obtuse
+     * @param a side length 1 of the triangle
+     * @param b side length 2 of the triangle
+     * @param c side length 3 of the triangle
+     * @return a boolean indicating whether side lengths a,b,c form an obtuse triangle
+     */
+    private boolean isTriangleObtuse(double a, double b, double c) {
+        return (2*Math.pow(Math.max(a,Math.max(b,c)), 2) > Math.pow(a,2)+Math.pow(b,2)+Math.pow(c,2));
+    }
 }
 

--- a/src/tests/LIC1Test.java
+++ b/src/tests/LIC1Test.java
@@ -12,17 +12,6 @@ public class LIC1Test {
      */
 
     @Test
-    public void assertThatLIC1ReturnsFalseWithInvalidCriteria() {
-        Parameters p = new Parameters();
-        p.RADIUS1 = 3.0;
-        int NUMPOINTS = 3;
-        double[] POINTSX = {1.0, 2.0, 3.0};
-        double[] POINTSY = {1.0, 2.0, 3.0};
-    
-        assertFalse((new LIC1()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
-
-    @Test
     public void assertThatTooSmallRadiusThrowsException() {
         Parameters p = new Parameters();
         p.RADIUS1 = -0.1;
@@ -30,7 +19,34 @@ public class LIC1Test {
         double[] POINTSX = {1.0, 2.0, 3.0};
         double[] POINTSY = {1.0, 2.0, 3.0};
         
-        assertThrows(AssertionError.class, () -> {(new LIC0()).evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+        assertThrows(AssertionError.class, () -> {(new LIC1()).evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    /*
+     * ------ FAILING TESTS ------
+     * Tests that the function evaluates to false when supposed to
+     */
+
+    @Test
+    public void assertThatLIC1ReturnsFalseWithInvalidCriteria() {
+        Parameters p = new Parameters();
+        p.RADIUS1 = 3.0;
+        int NUMPOINTS = 3;
+        double[] POINTSX = {1.0, 2.0, 3.0};
+        double[] POINTSY = {1.0, 2.0, 3.0};
+     
+        assertFalse((new LIC1()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
+    }
+
+    @Test
+    public void assertThatLIC1ReturnsFalseForSmallObtuseTriangle(){
+        Parameters p = new Parameters();
+        p.RADIUS1 = 1.0;
+        int NUMPOINTS = 3;
+        double[] POINTSX = {-1.0, 0.0, 1.0};
+        double[] POINTSY = {0.0, 0.5, 0.0};
+
+        assertFalse((new LIC1()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
 
     /*
@@ -46,6 +62,17 @@ public class LIC1Test {
         double[] POINTSX = {1.0, 2.0, 3.0};
         double[] POINTSY = {1.0, 2.0, 3.0};
   
+        assertTrue((new LIC1()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
+    }
+
+    @Test
+    public void assertThatLIC1ReturnsTrueForLargeAcuteTriangle(){
+        Parameters p = new Parameters();
+        p.RADIUS1 = 1.0;
+        int NUMPOINTS = 3;
+        double[] POINTSX = {-1.0, 0.0, 1.0};
+        double[] POINTSY = {0.0, 1.5, 0.0};
+
         assertTrue((new LIC1()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
 }


### PR DESCRIPTION
Fix bug in LIC#1 evaluate function so it can detect cases where points form an acute triangle with all side lengths less than or equal to 2*RADIUS1 but do not fit inside a circle of radius RADIUS1. Add corresponding test cases.
Also fix typo in test file where one test referenced LIC#0 instead of LIC#1.