### PR TITLE
Fix #50

### DIFF
--- a/src/LIC/LIC9.java
+++ b/src/LIC/LIC9.java
@@ -27,11 +27,11 @@ public class LIC9 implements LIC {
         //Bounder
         if(NUMPOINTS < 5)
             return false;
-        if(p.C_PTS < 1 || p.D_PTS < 1)
-            return false;
-        if(p.C_PTS + p.D_PTS > NUMPOINTS - 3)
-            return false;
-        
+
+        assert(p.C_PTS >= 1 && p.D_PTS >= 1);
+        assert(p.C_PTS + p.D_PTS <= NUMPOINTS - 3);
+        assert(p.EPSILON >= 0 && p.EPSILON < Math.PI); 
+
         for(int i = 0; i < NUMPOINTS - p.C_PTS - p.D_PTS - 2; ++i) {
             double x1 = POINTSX[i];
             double y1 = POINTSY[i];
@@ -42,11 +42,10 @@ public class LIC9 implements LIC {
 
             // Check if the angle is defined
             if (!arePointsCoincident(x1, y1, x2, y2) && !arePointsCoincident(x2, y2, x3, y3)) {
-                double angle = angle(x1, y1, x2, y2, x3, y3);
+                double angle = angle(x2, y2, x1, y1, x3, y3);
     
                 double epsilon1 = Math.PI - p.EPSILON;
-                double epsilon2 = Math.PI + p.EPSILON;
-    
+                double epsilon2 = Math.PI + p.EPSILON;    
                 // Check if the second point of the set of three points is always the vertex of the angle.
                 if (angle < epsilon1 || angle > epsilon2) {
                     return true;
@@ -72,7 +71,6 @@ public class LIC9 implements LIC {
         double dist23 = dist(x2, y2, x3, y3);
 
         double cosAngle = (Math.pow(dist12, 2) + Math.pow(dist13, 2) - Math.pow(dist23, 2)) / (2 * dist12 * dist13);
-
         // Make sure the value is within the valid range for acos
         cosAngle = Math.max(-1, Math.min(1, cosAngle));
 

--- a/src/tests/LIC9Test.java
+++ b/src/tests/LIC9Test.java
@@ -6,6 +6,99 @@ import LIC.*;
 
 public class LIC9Test {
     Parameters p = new Parameters();
+
+    /**
+     * INVALID INPUT TESTS
+     * Tests that evaluate function raises assertion error when given invalid parameter input.
+     */
+
+    @Test
+    public void assertThatCPTSLessThan1RaisesException() {
+        p.C_PTS = 0;
+        p.D_PTS = 1;
+        p.EPSILON = 0.01;
+        int NUMPOINTS = 8;
+
+        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
+        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
+        LIC9 lic9 = new LIC9();
+        assertThrows(AssertionError.class, () -> {lic9.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    @Test
+    public void assertThatDPTSLessThan1RaisesException() {
+        p.C_PTS = 1;
+        p.D_PTS = 0;
+        p.EPSILON = 0.01;
+        int NUMPOINTS = 8;
+
+        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
+        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
+        LIC9 lic9 = new LIC9();
+        assertThrows(AssertionError.class, () -> {lic9.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    @Test
+    public void assertThatEPSILONLessThan0RaisesException() {
+        p.C_PTS = 1;
+        p.D_PTS = 1;
+        p.EPSILON = -0.01;
+        int NUMPOINTS = 8;
+
+        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
+        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
+        LIC9 lic9 = new LIC9();
+        assertThrows(AssertionError.class, () -> {lic9.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    @Test
+    public void assertThatCPTSPlusDPTSTooLargeRaisesException() {
+        p.C_PTS = 2;
+        p.D_PTS = 4;
+        p.EPSILON = 0.01;
+        int NUMPOINTS = 8;
+
+        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
+        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
+        LIC9 lic9 = new LIC9();
+        assertThrows(AssertionError.class, () -> {lic9.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    /**
+     * FAILING TESTS
+     * Tests that evaluate function returns false when input does not satisfy LIC #9.
+     */
+
+     @Test
+    public void assertThatTooFewPointsReturnFalse() {
+        p.C_PTS = 1;
+        p.D_PTS = 1;
+        p.EPSILON = 3;
+        int NUMPOINTS = 4;
+
+        double[] POINTSX = {0, 1, 2, 3};
+        double[] POINTSY = {0, 1, 0, 1};
+        LIC9 lic9 = new LIC9();
+        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
+    }
+
+    @Test
+    public void assertThatInvalidCriteriaReturnFalse() {
+        p.C_PTS = 1;
+        p.D_PTS = 1;
+        p.EPSILON = 1.6;
+        int NUMPOINTS = 8;
+
+        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
+        double[] POINTSY = {0, 1, 0, 1.5, 2, 1, 0, 1.5};
+        LIC9 lic9 = new LIC9();
+        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
+    }
+
+    /**
+     * PASSING TESTS
+     * Tests that evaluate function returns true when input satisfies LIC #9. 
+     */
     
     @Test
     public void assertThatValidCriteriaWithLargeEpsilonReturnTrue() {
@@ -14,8 +107,8 @@ public class LIC9Test {
         p.EPSILON = 3;
         int NUMPOINTS = 8;
 
-        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
-        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
+        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 3};
+        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 0.9};
         LIC9 lic9 = new LIC9();
         assertTrue(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
@@ -31,70 +124,5 @@ public class LIC9Test {
         double[] POINTSY = {0, 1, 0, 1.5, 2, 1, 0, 1.5};
         LIC9 lic9 = new LIC9();
         assertTrue(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
-
-    @Test
-    public void assertThatInvalidCriteriaReturnFalse() {
-        p.C_PTS = 1;
-        p.D_PTS = 1;
-        p.EPSILON = 3;
-        int NUMPOINTS = 8;
-
-        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
-        double[] POINTSY = {0, 1, 0, 1.5, 2, 1, 0, 1.5};
-        LIC9 lic9 = new LIC9();
-        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
-
-    @Test
-    public void assertThatTooFewPointsReturnFalse() {
-        p.C_PTS = 1;
-        p.D_PTS = 1;
-        p.EPSILON = 3;
-        int NUMPOINTS = 4;
-
-        double[] POINTSX = {0, 1, 2, 3};
-        double[] POINTSY = {0, 1, 0, 1};
-        LIC9 lic9 = new LIC9();
-        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
-
-    @Test
-    public void assertThatCPTSLessThan1ReturnFalse() {
-        p.C_PTS = 0;
-        p.D_PTS = 1;
-        p.EPSILON = 0.01;
-        int NUMPOINTS = 8;
-
-        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
-        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
-        LIC9 lic9 = new LIC9();
-        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
-
-    @Test
-    public void assertThatDPTSLessThan1ReturnFalse() {
-        p.C_PTS = 1;
-        p.D_PTS = 0;
-        p.EPSILON = 0.01;
-        int NUMPOINTS = 8;
-
-        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
-        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
-        LIC9 lic9 = new LIC9();
-        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
-
-    @Test
-    public void assertThatCPTSPlusDPTSGreaterThanNumPointsReturnFalse() {
-        p.C_PTS = 2;
-        p.D_PTS = 4;
-        p.EPSILON = 0.01;
-        int NUMPOINTS = 8;
-
-        double[] POINTSX = {0, 1, 2, 3, 4, 5, 6, 7};
-        double[] POINTSY = {0, 1, 0, 1, 0, 1, 0, 1};
-        LIC9 lic9 = new LIC9();
-        assertFalse(lic9.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
 }


### PR DESCRIPTION
Fix bug in LIC#9 evaluate function so that the correct point is used as vertex in angle calculations. Also fix bug so that the evaluate function raises exceptions for invalid parameter input instead of returning false. Modify existing tests and add one new test to reflect correct output and exception behavior.