### PR TITLE
Fix #52

### DIFF
--- a/src/LIC/LIC12.java
+++ b/src/LIC/LIC12.java
@@ -18,13 +18,14 @@ public class LIC12 implements LIC {
      * @return a boolean stating whether the 12:th LIC is satisfied
      */
     public boolean evaluate(Parameters p, int NUMPOINTS, double[] POINTSX, double[] POINTSY) {
-        if (NUMPOINTS < 3) {
-            return false;
-        }
-
+        
         assert(0 <= p.LENGTH1);
         assert(0 <= p.LENGTH2);
         assert(1 <= p.K_PTS && p.K_PTS <= NUMPOINTS-2);
+
+        if (NUMPOINTS < 3) {
+            return false;
+        }
 
         boolean existsDistGreaterThanLength1 = false;
         boolean existsDistLessThanLength2 = false;

--- a/src/tests/LIC12Test.java
+++ b/src/tests/LIC12Test.java
@@ -66,21 +66,6 @@ public class LIC12Test {
      * ------ FAILING TESTS ------
      * Tests that the function evaluates to false when supposed to
      */
-    @Test
-    public void assertThatTooFewPointsReturnFalse() {
-        Parameters p = new Parameters();
-
-        p.K_PTS = 1;
-        p.LENGTH1 = 1;
-        p.LENGTH2 = 1;
-
-        int NUMPOINTS = 2;
-        double[] POINTSX = {0.0, 0.0};
-        double[] POINTSY = {0.0, 0.0};
-
-        LIC12 lic12 = new LIC12();
-        assertFalse(lic12.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
 
     @Test
     public void assertThatDistLessThanLength1ReturnsFalse() {


### PR DESCRIPTION
Fix bug in LIC#12 so that it handles invalid parameter input by raising an exception instead of returning false. Modify existing tests and add one new test accordingly to reflect correct behavior.