### PR TITLE
Fix #65

### DIFF
--- a/src/tests/LIC0Test.java
+++ b/src/tests/LIC0Test.java
@@ -10,16 +10,6 @@ public class LIC0Test {
      * INVALID INPUT TESTS
      * Tests that evaluate function raises assertion error when given invalid parameter input.
      */
-    @Test
-    public void assertThatLIC0ReturnsFalseWithInvalidCriteria() {
-        Parameters p = new Parameters();
-        p.LENGTH1 = 2.0;
-        int NUMPOINTS = 8;
-        double[] POINTSX = {0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0};
-        double[] POINTSY = {0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0};
-     
-        assertFalse((new LIC0()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
-    }
 
     @Test
     public void assertThatTooSmallLengthThrowsException() {
@@ -30,6 +20,21 @@ public class LIC0Test {
         double[] POINTSY = {0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0};
         
         assertThrows(AssertionError.class, () -> {(new LIC0()).evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    /*
+     * ------ FAILING TESTS ------
+     * Tests that the function evaluates to false when supposed to
+     */
+    @Test
+    public void assertThatLIC0ReturnsFalseWithInvalidCriteria() {
+        Parameters p = new Parameters();
+        p.LENGTH1 = 2.0;
+        int NUMPOINTS = 8;
+        double[] POINTSX = {0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0};
+        double[] POINTSY = {0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0};
+     
+        assertFalse((new LIC0()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
    
     /*

--- a/src/tests/LIC11Test.java
+++ b/src/tests/LIC11Test.java
@@ -8,16 +8,36 @@ import LIC.LIC11;
 public class LIC11Test {
     Parameters p = new Parameters();
 
-    @Test
-    public void assertThatValidCriteriaReturnTrue() {
-        p.G_PTS = 1;
+    /**
+     * INVALID INPUT TESTS
+     * Tests that evaluate function raises assertion error when given invalid parameter input.
+     */
+     @Test
+    public void assertThatGPTSLessThan1ReturnFasle() {
+        p.G_PTS = 0;
         int NUMPOINTS = 8;
 
         double[] POINTSX = {3, 2, 1, 3, 4, 5, 6, 7};
         double[] POINTSY = {0, 1, 1.5, 2, 2.5, 1.5, 0, 1};
         LIC11 lic11 = new LIC11();
-        assertTrue(lic11.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
+        assertThrows(AssertionError.class, () -> {lic11.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
     }
+
+    @Test
+    public void assertThatGPTSGreaterThanNumpointsReturnFasle() {
+        p.G_PTS = 7;
+        int NUMPOINTS = 8;
+
+        double[] POINTSX = {3, 2, 1, 3, 4, 5, 6, 7};
+        double[] POINTSY = {0, 1, 1.5, 2, 2.5, 1.5, 0, 1};
+        LIC11 lic11 = new LIC11();
+        assertThrows(AssertionError.class, () -> {lic11.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+    }
+
+    /*
+     * ------ FAILING TESTS ------
+     * Tests that the function evaluates to false when supposed to
+     */
 
     @Test
     public void assertThatInvalidCriteriaReturnFasle() {
@@ -41,25 +61,19 @@ public class LIC11Test {
         assertFalse(lic11.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
 
+    /*
+     * ------ PASSING TESTS ------
+     * Tests that the function evaluates to true when supposed to
+     */
+
     @Test
-    public void assertThatGPTSLessThan1ReturnFasle() {
-        p.G_PTS = 0;
+    public void assertThatValidCriteriaReturnTrue() {
+        p.G_PTS = 1;
         int NUMPOINTS = 8;
 
         double[] POINTSX = {3, 2, 1, 3, 4, 5, 6, 7};
         double[] POINTSY = {0, 1, 1.5, 2, 2.5, 1.5, 0, 1};
         LIC11 lic11 = new LIC11();
-        assertThrows(AssertionError.class, () -> {lic11.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
-    }
-
-    @Test
-    public void assertThatGPTSGreaterThanNumpointsReturnFasle() {
-        p.G_PTS = 7;
-        int NUMPOINTS = 8;
-
-        double[] POINTSX = {3, 2, 1, 3, 4, 5, 6, 7};
-        double[] POINTSY = {0, 1, 1.5, 2, 2.5, 1.5, 0, 1};
-        LIC11 lic11 = new LIC11();
-        assertThrows(AssertionError.class, () -> {lic11.evaluate(p,NUMPOINTS,POINTSX,POINTSY);});
+        assertTrue(lic11.evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
 }

--- a/src/tests/LIC2Test.java
+++ b/src/tests/LIC2Test.java
@@ -7,9 +7,9 @@ import LIC.LIC2;
 
 public class LIC2Test {
     
-    /*
-     * ------ FAILING TESTS ------
-     * Tests that the function evaluates to false when supposed to
+    /**
+     * INVALID INPUT TESTS
+     * Tests that evaluate function raises assertion error when given invalid parameter input.
      */
    
     @Test
@@ -27,6 +27,11 @@ public class LIC2Test {
         });
     }
 
+    /*
+     * ------ FAILING TESTS ------
+     * Tests that the function evaluates to false when supposed to
+     */
+    
     @Test
     public void assertThatLIC2ReturnsFalseWithTooFewPoints() {
         Parameters p = new Parameters();

--- a/src/tests/LIC3Test.java
+++ b/src/tests/LIC3Test.java
@@ -11,16 +11,6 @@ public class LIC3Test {
      * INVALID INPUT TESTS
      * Tests that evaluate function raises assertion error when given invalid parameter input.
      */
-
-    @Test
-    public void assertThatLIC3ReturnsFalseWithTooFewPoints(){
-        Parameters p = new Parameters();
-        p.AREA1 = 1;
-        int NUMPOINTS = 2;
-        double[] POINTSX = {0.0,1.0};
-        double[] POINTSY = {0.0,1.0};
-        assertFalse((new LIC3()).evaluate(p,NUMPOINTS,POINTSX,POINTSY));
-    }
     
     @Test
     public void assertThatTooSmallAreaThrowsException() {
@@ -33,7 +23,22 @@ public class LIC3Test {
             (new LIC3()).evaluate(p, NUMPOINTS, POINTSX, POINTSY);
         });
     }
-
+    
+    /*
+     * ------ FAILING TESTS ------
+     * Tests that the function evaluates to false when supposed to
+     */
+    
+    @Test
+    public void assertThatLIC3ReturnsFalseWithTooFewPoints(){
+        Parameters p = new Parameters();
+        p.AREA1 = 1;
+        int NUMPOINTS = 2;
+        double[] POINTSX = {0.0,1.0};
+        double[] POINTSY = {0.0,1.0};
+        assertFalse((new LIC3()).evaluate(p,NUMPOINTS,POINTSX,POINTSY));
+    }
+    
     @Test
     public void assertThatLIC3ReturnsFalseWithInvalidInput() {
         Parameters p = new Parameters();
@@ -43,6 +48,7 @@ public class LIC3Test {
         double[] POINTSY = {0.0,0.0,1.0};
         assertFalse((new LIC3()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
+    
     /**
      * PASSING TESTS
      * Tests that function returns true when input satisfies LIC #3. 

--- a/src/tests/LIC5Test.java
+++ b/src/tests/LIC5Test.java
@@ -7,10 +7,11 @@ import LIC.LIC5;
 
 public class LIC5Test {
 
-    /**
-     * INVALID INPUT TESTS
-     * Tests that evaluate function raises assertion error when given invalid parameter input.
+    /*
+     * ------ FAILING TESTS ------
+     * Tests that the function evaluates to false when supposed to
      */
+    
     @Test
     public void assertThatTooFewPointsReturnFalse() {
         Parameters p = new Parameters();
@@ -20,11 +21,6 @@ public class LIC5Test {
         assertFalse((new LIC5()).evaluate(p, NUMPOINTS, POINTSX, POINTSY));
     }
     
-    /*
-     * ------ FAILING TESTS ------
-     * Tests that the function evaluates to false when supposed to
-     */
-   
     @Test
     public void assertThatReturnsFalseForInvalidInput() {
         Parameters p = new Parameters();


### PR DESCRIPTION
Refactor test comments so that the nature of the test matches the comment above, by moving or adding a comment

Moved some tests so that every test file follows the convention below:
1. INVALID TESTS
2. FAILING TESTS
3. PASSING TESTS